### PR TITLE
Feature/authenticator

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,8 +1,11 @@
+const bodyParser = require('body-parser');
 const cookieParser = require('cookie-parser');
 const express = require('express');
 const httpErrors = require('http-errors');
 const logger = require('morgan');
 const path = require('path');
+const passport = require('passport');
+const LocalStrategy = require('passport-local').Strategy;
 
 const indexRouter = require('./routes/index');
 
@@ -12,6 +15,17 @@ app.use(logger('dev'));
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
+app.use(bodyParser.urlencoded({ extended: true }));
+app.use(passport.initialize());
+
+passport.use(new LocalStrategy((username, password, done) => {
+  // TODO: ユーザの認証機構の実装
+  if (username === 'username' && password === 'password') {
+    return done(null, username);
+  }
+
+  return done(null, false);
+}));
 
 app.use(express.static(path.join(__dirname, 'public')));
 

--- a/app.js
+++ b/app.js
@@ -1,3 +1,5 @@
+require('./lib/passport.js');
+
 const bodyParser = require('body-parser');
 const cookieParser = require('cookie-parser');
 const express = require('express');
@@ -5,8 +7,6 @@ const httpErrors = require('http-errors');
 const logger = require('morgan');
 const path = require('path');
 const passport = require('passport');
-const LocalStrategy = require('passport-local').Strategy;
-
 const indexRouter = require('./routes/index');
 
 const app = express();
@@ -17,15 +17,6 @@ app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(passport.initialize());
-
-passport.use(new LocalStrategy((username, password, done) => {
-  // TODO: ユーザの認証機構の実装
-  if (username === 'username' && password === 'password') {
-    return done(null, username);
-  }
-
-  return done(null, false);
-}));
 
 app.use(express.static(path.join(__dirname, 'public')));
 

--- a/lib/passport.js
+++ b/lib/passport.js
@@ -1,0 +1,13 @@
+'use strcit';
+
+const passport = require('passport/lib');
+const LocalStrategy = require('passport-local/lib').Strategy;
+
+passport.use(new LocalStrategy((username, password, done) => {
+  // TODO: ユーザの認証機構の実装
+  if (username === 'username' && password === 'password') {
+    return done(null, username);
+  }
+
+  return done(null, false);
+}));

--- a/lib/passport.js
+++ b/lib/passport.js
@@ -2,6 +2,9 @@
 
 const passport = require('passport/lib');
 const LocalStrategy = require('passport-local/lib').Strategy;
+const JwtStrategy = require('passport-jwt').Strategy;
+const { ExtractJwt } = require('passport-jwt');
+
 
 passport.use(new LocalStrategy((username, password, done) => {
   // TODO: ユーザの認証機構の実装
@@ -11,3 +14,8 @@ passport.use(new LocalStrategy((username, password, done) => {
 
   return done(null, false);
 }));
+
+passport.use(new JwtStrategy({
+  jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+  secretOrKey: 'secret'
+}, (payload, done) => done(null, payload)));

--- a/package-lock.json
+++ b/package-lock.json
@@ -2081,6 +2081,15 @@
         "pause": "0.0.1"
       }
     },
+    "passport-jwt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-4.0.0.tgz",
+      "integrity": "sha512-BwC0n2GP/1hMVjR4QpnvqA61TxenUMlmfNjYNgK0ZAs0HK4SOQkHcSv4L328blNTLtHq7DbmvyNJiH+bn6C5Mg==",
+      "requires": {
+        "jsonwebtoken": "^8.2.0",
+        "passport-strategy": "^1.0.0"
+      }
+    },
     "passport-local": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -250,6 +250,11 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -525,6 +530,14 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "ee-first": {
@@ -1443,6 +1456,23 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      }
+    },
     "jsx-ast-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
@@ -1450,6 +1480,25 @@
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3"
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "lcid": {
@@ -1498,6 +1547,41 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "log-symbols": {
       "version": "2.2.0",
@@ -2301,8 +2385,7 @@
     "semver": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-      "dev": true
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
     },
     "send": {
       "version": "0.16.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1988,6 +1988,28 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
     },
+    "passport": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.0.tgz",
+      "integrity": "sha1-xQlWkTR71a07XhgCOMORTRbwWBE=",
+      "requires": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1"
+      }
+    },
+    "passport-local": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
+      "integrity": "sha1-H+YyaMkudWBmJkN+O5BmYsFbpu4=",
+      "requires": {
+        "passport-strategy": "1.x.x"
+      }
+    },
+    "passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -2037,6 +2059,11 @@
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
+    },
+    "pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
     "pify": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "debug": "^4.1.1",
     "express": "^4.16.4",
     "http-errors": "^1.7.1",
+    "jsonwebtoken": "^8.5.1",
     "morgan": "^1.9.1",
     "passport": "^0.4.0",
     "passport-local": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -9,11 +9,14 @@
     "test": "mocha --recursive"
   },
   "dependencies": {
+    "body-parser": "^1.18.3",
     "cookie-parser": "^1.4.3",
     "debug": "^4.1.1",
     "express": "^4.16.4",
     "http-errors": "^1.7.1",
     "morgan": "^1.9.1",
+    "passport": "^0.4.0",
+    "passport-local": "^1.0.0",
     "run": "^1.4.0",
     "start": "^5.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "jsonwebtoken": "^8.5.1",
     "morgan": "^1.9.1",
     "passport": "^0.4.0",
+    "passport-jwt": "^4.0.0",
     "passport-local": "^1.0.0",
     "run": "^1.4.0",
     "start": "^5.1.0"

--- a/routes/index.js
+++ b/routes/index.js
@@ -21,4 +21,11 @@ router.post('/login',
     });
   });
 
+/* ログイン済みユーザのリクエストしか受け付けないAPIの例 */
+router.get('/secure', passport.authenticate('jwt', { session: false }), (req, res) => {
+  res.json({
+    req: req.user
+  });
+});
+
 module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,6 +1,7 @@
 const { Router } = require('express');
 
 const router = Router();
+const passport = require('passport');
 
 /* GET index page. */
 router.get('/', (req, res) => {
@@ -8,5 +9,13 @@ router.get('/', (req, res) => {
     title: 'Express'
   });
 });
+
+router.post('/login',
+  passport.authenticate('local', { session: false }),
+  (req, res) => {
+    res.json({
+      user: req.user
+    });
+  });
 
 module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,6 +1,7 @@
 const { Router } = require('express');
 
 const router = Router();
+const jwt = require('jsonwebtoken');
 const passport = require('passport');
 
 /* GET index page. */
@@ -13,8 +14,10 @@ router.get('/', (req, res) => {
 router.post('/login',
   passport.authenticate('local', { session: false }),
   (req, res) => {
+    const token = jwt.sign({ user: req.user }, 'secret');
+
     res.json({
-      user: req.user
+      token
     });
   });
 

--- a/test/app-test.js
+++ b/test/app-test.js
@@ -17,6 +17,20 @@ describe('app index route', () => {
       });
   });
 
+  it('it should POST /login with username:password', (done) => {
+    chai.request(app)
+      .post('/login')
+      .type('form')
+      .send({
+        username: 'username',
+        password: 'password'
+      })
+      .end((err, res) => {
+        res.should.have.status(200);
+        done();
+      });
+  });
+
   it('it should handle 404 error', (done) => {
     chai.request(app)
       .get('/notExist')

--- a/test/app-test.js
+++ b/test/app-test.js
@@ -31,6 +31,20 @@ describe('app index route', () => {
       });
   });
 
+  it('it should not POST /login with bad username:password', (done) => {
+    chai.request(app)
+      .post('/login')
+      .type('form')
+      .send({
+        username: 'baduser',
+        password: 'badpassword'
+      })
+      .end((err, res) => {
+        res.should.have.status(401);
+        done();
+      });
+  });
+
   it('it should handle 404 error', (done) => {
     chai.request(app)
       .get('/notExist')


### PR DESCRIPTION
JWTを用いてAPIを叩いた際に認証する機能を実装。
GoogleAuthを用いた認証はフロントエンドが必要なので後々置き換え、ミドルウェアとして定義してあるので、/loginの処理変更のみで対応可能。

TODO: GoogleAuthでの認証の実装
TODO: シークレットを強固なものに設定する